### PR TITLE
Fix memoizeIdentifier where id could be undefined

### DIFF
--- a/packages/forgetti/src/core/optimizer.ts
+++ b/packages/forgetti/src/core/optimizer.ts
@@ -217,8 +217,14 @@ export default class Optimizer {
 
   memoizeIdentifier(
     path: babel.NodePath,
-    id: t.Identifier,
+    id: t.Identifier | undefined,
   ) {
+    // For some reason, "id" could be undefined. Might be an edge case in large projects
+    // For now we just "skip"
+    if (!id) {
+      return optimizedExpr(id, undefined, true);
+    }
+
     // Check if scope has the binding (no globals)
     // we only want to memoize identifiers
     // that are part of the render evaluation


### PR DESCRIPTION
I was playing with forgetti in some of my hobby react projects when this error happens:

```
TypeError: unknown file: Cannot read properties of undefined (reading 'name')
    at Optimizer.memoizeIdentifier (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:557:34)
    at Optimizer.optimizeObjectExpression (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:964:34)
    at Optimizer.optimizeExpression (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:1185:19)
    at Optimizer.createDependency (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:541:28)
    at Optimizer.optimizeCallExpression (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:808:36)
    at Optimizer.optimizeExpression (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:1170:19)
    at Optimizer.optimizeVariableDeclaration (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:1216:49)
    at Optimizer.optimizeStatement (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:1358:12)
    at Optimizer.optimizeBlock (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:1247:12)
    at Optimizer.optimizeFunctionComponent (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:1394:10)
    at Optimizer.optimize (/Users/sukka/[redacted]/node_modules/forgetti/dist/cjs/development/index.cjs:1402:12)
```

It turns out that the second parameter of `memoizeIdentifier` could be `undefined`. I don't know why and I am not able to grab a minimum re-production (yet!). For now, I just make `memoizeIdentifier` skip when `id` is falsy.