### PR TITLE
Feat: accept exclude components options

### DIFF
--- a/packages/forgetti/src/core/checks.ts
+++ b/packages/forgetti/src/core/checks.ts
@@ -28,7 +28,20 @@ export function isHookOrComponentName(ctx: StateContext, id: t.Identifier): bool
   return ctx.filters.component.test(id.name) || isHookName(ctx, id);
 }
 
-export function isComponentNameValid(
+export function isNodeShouldBeSkipped(node: t.Node): boolean {
+  // Node without leading comments shouldn't be skipped
+  if (!node.leadingComments) {
+    return false;
+  }
+
+  if (node.leadingComments.some((comment) => comment.value.includes('@forgetti skip'))) {
+    return true;
+  }
+
+  return false;
+}
+
+export function isComponentValid(
   ctx: StateContext,
   node: ComponentNode,
   checkName: boolean,
@@ -37,6 +50,7 @@ export function isComponentNameValid(
     node.type !== 'ArrowFunctionExpression'
     && !!node.id
     && isHookOrComponentName(ctx, node.id)
+    && !isNodeShouldBeSkipped(node)
   );
 }
 

--- a/packages/forgetti/test/__snapshots__/forgetti-skip.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/forgetti-skip.test.ts.snap
@@ -1,0 +1,81 @@
+// Vitest Snapshot v1
+
+exports[`forgetti skip > should optimize non-skipped function declaration 1`] = `
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$equals as _$$equals } from \\"forgetti/runtime\\";
+function Example(props) {
+  let _c = _$$cache(_useMemo, 6),
+    _eq = _$$equals(_c, 0, props),
+    _v = _eq ? _c[0] : _c[0] = props,
+    _v2 = _eq ? _c[1] : _c[1] = _v.className,
+    _eq2 = _$$equals(_c, 2, _v2),
+    _v3 = _eq2 ? _c[2] : _c[2] = _v2,
+    _v4 = _eq ? _c[3] : _c[3] = _v.children,
+    _eq3 = _$$equals(_c, 4, _v4),
+    _v5 = _eq3 ? _c[4] : _c[4] = _v4;
+  return _eq2 && _eq3 ? _c[5] : _c[5] = <h1 className={_v3}>{_v5}</h1>;
+}"
+`;
+
+exports[`forgetti skip > should optimize non-skipped function expression 1`] = `
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$equals as _$$equals } from \\"forgetti/runtime\\";
+const Example = function (props) {
+  let _c = _$$cache(_useMemo, 6),
+    _eq = _$$equals(_c, 0, props),
+    _v = _eq ? _c[0] : _c[0] = props,
+    _v2 = _eq ? _c[1] : _c[1] = _v.className,
+    _eq2 = _$$equals(_c, 2, _v2),
+    _v3 = _eq2 ? _c[2] : _c[2] = _v2,
+    _v4 = _eq ? _c[3] : _c[3] = _v.children,
+    _eq3 = _$$equals(_c, 4, _v4),
+    _v5 = _eq3 ? _c[4] : _c[4] = _v4;
+  return _eq2 && _eq3 ? _c[5] : _c[5] = <h1 className={_v3}>{_v5}</h1>;
+};"
+`;
+
+exports[`forgetti skip > should optimize non-skipped variable declaration 1`] = `
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$equals as _$$equals } from \\"forgetti/runtime\\";
+const Example = props => {
+  let _c = _$$cache(_useMemo, 6),
+    _eq = _$$equals(_c, 0, props),
+    _v = _eq ? _c[0] : _c[0] = props,
+    _v2 = _eq ? _c[1] : _c[1] = _v.className,
+    _eq2 = _$$equals(_c, 2, _v2),
+    _v3 = _eq2 ? _c[2] : _c[2] = _v2,
+    _v4 = _eq ? _c[3] : _c[3] = _v.children,
+    _eq3 = _$$equals(_c, 4, _v4),
+    _v5 = _eq3 ? _c[4] : _c[4] = _v4;
+  return _eq2 && _eq3 ? _c[5] : _c[5] = <h1 className={_v3}>{_v5}</h1>;
+};"
+`;
+
+exports[`forgetti skip > should skip skipped function declaration 1`] = `
+"/** @@forgetti skip */function Example(props) {
+  return <h1 className={props.className}>{props.children}</h1>;
+}"
+`;
+
+exports[`forgetti skip > should skip skipped function expression 1`] = `
+"const /** @@forgetti skip */ExampleA = function (props) {
+  return <h1 className={props.className}>{props.children}</h1>;
+};
+/** @@forgetti skip */
+const ExampleB = function (props) {
+  return <h1 className={props.className}>{props.children}</h1>;
+};"
+`;
+
+exports[`forgetti skip > should skip skipped variable declaration 1`] = `
+"const /** @@forgetti skip */ExampleA = props => {
+  return <h1 className={props.className}>{props.children}</h1>;
+};
+/** @@forgetti skip */
+const ExampleB = props => {
+  return <h1 className={props.className}>{props.children}</h1>;
+};"
+`;

--- a/packages/forgetti/test/forgetti-skip.test.ts
+++ b/packages/forgetti/test/forgetti-skip.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable no-template-curly-in-string */
+import * as babel from '@babel/core';
+import { describe, expect, it } from 'vitest';
+import type { Options } from '../src';
+import plugin from '../src';
+
+const options: Options = {
+  preset: 'react',
+};
+
+async function compile(code: string): Promise<string> {
+  const result = await babel.transformAsync(code, {
+    plugins: [
+      [plugin, options],
+    ],
+    parserOpts: {
+      plugins: [
+        'jsx',
+      ],
+    },
+  });
+
+  return result?.code ?? '';
+}
+
+describe('forgetti skip', () => {
+  it('should optimize non-skipped function declaration', async () => {
+    const code = `
+function Example(props) {
+  return <h1 className={props.className}>{props.children}</h1>;
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
+
+  it('should skip skipped function declaration', async () => {
+    const code = `
+/** @@forgetti skip */ function Example(props) {
+  return <h1 className={props.className}>{props.children}</h1>;
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
+
+  it('should optimize non-skipped function expression', async () => {
+    const code = `
+const Example = function (props) {
+  return <h1 className={props.className}>{props.children}</h1>;
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
+
+  it('should skip skipped function expression', async () => {
+    const code = `
+const /** @@forgetti skip */ ExampleA = function (props) {
+  return <h1 className={props.className}>{props.children}</h1>;
+}
+/** @@forgetti skip */ const ExampleB = function (props) {
+  return <h1 className={props.className}>{props.children}</h1>;
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
+
+  it('should optimize non-skipped variable declaration', async () => {
+    const code = `
+const Example = props => {
+  return <h1 className={props.className}>{props.children}</h1>;
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
+
+  it('should skip skipped variable declaration', async () => {
+    const code = `
+const /** @@forgetti skip */ ExampleA = props => {
+  return <h1 className={props.className}>{props.children}</h1>;
+}
+/** @@forgetti skip */ const ExampleB = props => {
+  return <h1 className={props.className}>{props.children}</h1>;
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This PR addresses #16.

~~`excludeComponentsFilter` is added aside from `preset` since `preset` is general while `excludeComponentsFilter` is project-specific.~~