### PR TITLE
Fix nested hook call

### DIFF
--- a/packages/forgetti/src/core/checks.ts
+++ b/packages/forgetti/src/core/checks.ts
@@ -75,7 +75,7 @@ export function isNestedExpression(node: t.Node): node is NestedExpression {
 
 export function isHookCall(
   ctx: StateContext,
-  path: babel.NodePath<any>,
+  path: babel.NodePath<t.Node | null>,
 ): boolean {
   if (isPathValid(path, t.isCallExpression)) {
     // A simple check to see if "node.callee" is an Identifier

--- a/packages/forgetti/src/core/checks.ts
+++ b/packages/forgetti/src/core/checks.ts
@@ -72,28 +72,3 @@ export function isNestedExpression(node: t.Node): node is NestedExpression {
       return false;
   }
 }
-
-export function isHookCall(
-  ctx: StateContext,
-  path: babel.NodePath<t.Node | null>,
-): boolean {
-  if (isPathValid(path, t.isCallExpression)) {
-    // A simple check to see if "node.callee" is an Identifier
-    // TypeScript can infer the type of "node.callee" to Identifier or V8IntrinsicIdentifier
-    if (!('name' in path.node.callee)) {
-      return false;
-    }
-
-    // Check if callee is a react hook
-    if (!ctx.filters.hook) {
-      return false;
-    }
-    return ctx.filters.hook.test(path.node.callee.name);
-  }
-
-  if (isPathValid(path, t.isSpreadElement)) {
-    return isHookCall(ctx, path.get('argument'));
-  }
-
-  return false;
-}

--- a/packages/forgetti/src/core/checks.ts
+++ b/packages/forgetti/src/core/checks.ts
@@ -1,4 +1,4 @@
-import * as t from '@babel/types';
+import type * as t from '@babel/types';
 import type * as babel from '@babel/core';
 import type { ComponentNode, StateContext } from './types';
 

--- a/packages/forgetti/src/core/is-contains-hook.ts
+++ b/packages/forgetti/src/core/is-contains-hook.ts
@@ -1,0 +1,314 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import type * as babel from '@babel/core';
+import * as t from '@babel/types';
+import { isNestedExpression, isPathValid } from './checks';
+import type OptimizerScope from './optimizer-scope';
+import type { ComponentNode, StateContext } from './types';
+import unwrapNode from './unwrap-node';
+
+interface OptimizerInstance {
+  ctx: StateContext;
+  scope: OptimizerScope;
+  path: babel.NodePath<ComponentNode>;
+}
+
+function isTemplateLiteralContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.TemplateLiteral>,
+): boolean {
+  const expressions = path.get('expressions');
+  for (let i = 0, len = expressions.length; i < len; i++) {
+    const expr = expressions[i];
+    if (isPathValid(expr, t.isExpression) && isContainsHook(instance, expr)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isConditionalExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.ConditionalExpression>,
+): boolean {
+  return isContainsHook(instance, path.get('test'));
+}
+
+function isBinaryExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.BinaryExpression>,
+): boolean {
+  const left = path.get('left');
+  if (isPathValid(left, t.isExpression) && isContainsHook(instance, left)) {
+    return true;
+  }
+  const right = path.get('right');
+  if (isPathValid(right, t.isExpression) && isContainsHook(instance, right)) {
+    return true;
+  }
+  return false;
+}
+
+function isLogicalExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.LogicalExpression>,
+): boolean {
+  return isContainsHook(instance, path.get('left')) || isContainsHook(instance, path.get('right'));
+}
+
+function isUnaryExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.UnaryExpression>,
+): boolean {
+  return isContainsHook(instance, path.get('argument'));
+}
+
+function isCallExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.CallExpression | t.OptionalCallExpression>,
+): boolean {
+  const callee = path.get('callee');
+
+  if (isPathValid(callee, t.isExpression)) {
+    const trueID = unwrapNode(callee.node, t.isIdentifier);
+    if (trueID) {
+      const binding = path.scope.getBindingIdentifier(trueID.name);
+      if (binding) {
+        const registration = instance.ctx.registrations.hooks.get(binding);
+        if (registration) {
+          return false;
+        }
+        if (instance.ctx.filters.hook?.test(trueID.name)) {
+          return true;
+        }
+      }
+    }
+    const trueMember = unwrapNode(callee.node, t.isMemberExpression);
+    if (
+      trueMember
+      && !trueMember.computed
+      && t.isIdentifier(trueMember.property)
+    ) {
+      const obj = unwrapNode(trueMember.object, t.isIdentifier);
+      if (obj) {
+        const binding = path.scope.getBindingIdentifier(obj.name);
+        if (binding) {
+          const registrations = instance.ctx.registrations.hooksNamespaces.get(binding);
+          if (registrations) {
+            for (let i = 0, len = registrations.length; i < len; i += 1) {
+              const registration = registrations[i];
+              if (registration.name === trueMember.property.name) {
+                return false;
+              }
+            }
+          }
+        }
+      }
+      if (instance.ctx.filters.hook?.test(trueMember.property.name)) {
+        return true;
+      }
+    }
+    if (isContainsHook(instance, callee)) {
+      return true;
+    }
+  }
+  const args = path.get('arguments');
+  for (let i = 0, len = args.length; i < len; i++) {
+    const arg = args[i];
+    if (isPathValid(arg, t.isExpression) && isContainsHook(instance, arg)) {
+      return true;
+    }
+    if (isPathValid(arg, t.isSpreadElement) && isContainsHook(instance, arg.get('argument'))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isArrayExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.ArrayExpression | t.TupleExpression>,
+): boolean {
+  const elements = path.get('elements');
+  for (let i = 0, len = elements.length; i < len; i++) {
+    const element = elements[i];
+    if (isPathValid(element, t.isSpreadElement) && isContainsHook(instance, element.get('argument'))) {
+      return true;
+    }
+    if (isPathValid(element, t.isExpression) && isContainsHook(instance, element)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isObjectExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.ObjectExpression | t.RecordExpression>,
+): boolean {
+  const properties = path.get('properties');
+  for (let i = 0, len = properties.length; i < len; i++) {
+    const property = properties[i];
+    if (isPathValid(property, t.isSpreadElement) && isContainsHook(instance, property.get('argument'))) {
+      return true;
+    }
+    if (isPathValid(property, t.isObjectProperty)) {
+      if (property.node.computed) {
+        const key = property.get('key');
+        if (isPathValid(key, t.isExpression) && isContainsHook(instance, key)) {
+          return true;
+        }
+      }
+      const value = property.get('value');
+      if (isPathValid(value, t.isExpression) && isContainsHook(instance, value)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isSequenceExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.SequenceExpression>,
+): boolean {
+  const exprs = path.get('expressions');
+  for (let i = 0, len = exprs.length; i < len; i++) {
+    if (isContainsHook(instance, exprs[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isJSXChildrenContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.JSXFragment | t.JSXElement>,
+): boolean {
+  const children = path.get('children');
+  for (let i = 0, len = children.length; i < len; i++) {
+    const child = children[i];
+    if (isPathValid(child, t.isJSXElement) && isJSXElementContainsHook(instance, child)) {
+      return true;
+    }
+    if (isPathValid(child, t.isJSXFragment) && isJSXChildrenContainsHook(instance, child)) {
+      return true;
+    }
+    if (isPathValid(child, t.isJSXSpreadChild) && isContainsHook(instance, child.get('expression'))) {
+      return true;
+    }
+    if (isPathValid(child, t.isJSXExpressionContainer)) {
+      const expr = child.get('expression');
+      if (isPathValid(expr, t.isExpression) && isContainsHook(instance, expr)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isJSXElementContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.JSXElement>,
+): boolean {
+  return isJSXChildrenContainsHook(instance, path);
+}
+
+function isAssignmentExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.AssignmentExpression>,
+): boolean {
+  const left = path.get('left');
+  if (isPathValid(left, t.isExpression) && isContainsHook(instance, left)) {
+    return true;
+  }
+  const right = path.get('right');
+  if (isPathValid(right, t.isExpression) && isContainsHook(instance, right)) {
+    return true;
+  }
+  return false;
+}
+
+function isTaggedTemplateExpressionContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.TaggedTemplateExpression>,
+): boolean {
+  return isContainsHook(instance, path.get('tag'))
+    || isContainsHook(instance, path.get('quasi'));
+}
+
+export default function isContainsHook(
+  instance: OptimizerInstance,
+  path: babel.NodePath<t.Expression>,
+): boolean {
+  if (isPathValid(path, isNestedExpression)) {
+    return isContainsHook(instance, path.get('expression'));
+  }
+  if (isPathValid(path, t.isLiteral)) {
+    if (isPathValid(path, t.isTemplateLiteral)) {
+      return isTemplateLiteralContainsHook(instance, path);
+    }
+    return false;
+  }
+  if (isPathValid(path, t.isIdentifier)) {
+    return false;
+  }
+  if (isPathValid(path, t.isMemberExpression) || isPathValid(path, t.isOptionalMemberExpression)) {
+    return false;
+  }
+  if (isPathValid(path, t.isConditionalExpression)) {
+    return isConditionalExpressionContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isBinaryExpression)) {
+    return isBinaryExpressionContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isLogicalExpression)) {
+    return isLogicalExpressionContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isUnaryExpression)) {
+    return isUnaryExpressionContainsHook(instance, path);
+  }
+  if (
+    isPathValid(path, t.isCallExpression)
+    || isPathValid(path, t.isOptionalCallExpression)
+  ) {
+    return isCallExpressionContainsHook(instance, path);
+  }
+  if (
+    isPathValid(path, t.isFunctionExpression)
+    || isPathValid(path, t.isArrowFunctionExpression)
+  ) {
+    return false;
+  }
+  if (isPathValid(path, t.isAssignmentExpression)) {
+    return isAssignmentExpressionContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isArrayExpression) || isPathValid(path, t.isTupleExpression)) {
+    return isArrayExpressionContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isObjectExpression) || isPathValid(path, t.isRecordExpression)) {
+    return isObjectExpressionContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isNewExpression)) {
+    return false;
+  }
+  if (isPathValid(path, t.isSequenceExpression)) {
+    return isSequenceExpressionContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isTaggedTemplateExpression)) {
+    return isTaggedTemplateExpressionContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isJSXFragment)) {
+    return isJSXChildrenContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isJSXElement)) {
+    return isJSXElementContainsHook(instance, path);
+  }
+  if (isPathValid(path, t.isImport)) {
+    return false;
+  }
+  if (isPathValid(path, t.isMetaProperty)) {
+    return false;
+  }
+  return false;
+}

--- a/packages/forgetti/src/core/optimizer.ts
+++ b/packages/forgetti/src/core/optimizer.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import type * as babel from '@babel/core';
 import * as t from '@babel/types';
-import { isCallExpressionAndHook, isNestedExpression, isPathValid } from './checks';
+import { isExpressionAndHook, isNestedExpression, isPathValid } from './checks';
 import getForeignBindings, { isForeignBinding } from './get-foreign-bindings';
 import getImportIdentifier from './get-import-identifier';
 import { RUNTIME_EQUALS } from './imports';
@@ -561,7 +561,7 @@ export default class Optimizer {
         for (let i = 0, len = argumentsPath.length; i < len; i++) {
           argument = argumentsPath[i];
           if (isPathValid(argument, t.isExpression)) {
-            if (isCallExpressionAndHook(this.ctx, argument.node)) {
+            if (isExpressionAndHook(this.ctx, argument.node)) {
               continue;
             }
 
@@ -571,6 +571,10 @@ export default class Optimizer {
               path.node.arguments[i] = optimized.expr;
             }
           } else if (isPathValid(argument, t.isSpreadElement)) {
+            if (isExpressionAndHook(this.ctx, argument.node.argument)) {
+              continue;
+            }
+
             const optimized = this.createDependency(argument.get('argument'));
             if (optimized) {
               mergeDependencies(dependencies, optimized.deps);

--- a/packages/forgetti/src/core/optimizer.ts
+++ b/packages/forgetti/src/core/optimizer.ts
@@ -338,7 +338,6 @@ export default class Optimizer {
       return optimizedExpr(path.node);
     }
     const leftPath = path.get('left');
-    const rightPath = path.get('right');
 
     const dependencies = createDependencies();
 
@@ -349,7 +348,7 @@ export default class Optimizer {
         mergeDependencies(dependencies, left.deps);
       }
     }
-    const right = this.createDependency(rightPath);
+    const right = this.createDependency(path.get('right'));
     if (right) {
       path.node.right = right.expr;
       mergeDependencies(dependencies, right.deps);
@@ -654,15 +653,13 @@ export default class Optimizer {
   optimizeAssignmentExpression(
     path: babel.NodePath<t.AssignmentExpression>,
   ): OptimizedExpression {
-    const rightPath = path.get('right');
-
     // TODO Work on left node
     const dependencies = createDependencies();
     const left = this.optimizeLVal(path.get('left'), true);
     path.node.left = left.expr;
     mergeDependencies(dependencies, left.deps);
 
-    const right = this.createDependency(rightPath);
+    const right = this.createDependency(path.get('right'));
     if (right) {
       path.node.right = right.expr;
       mergeDependencies(dependencies, right.deps);

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -20,7 +20,9 @@ function Example(props) {
     [useA()]: useB(),
     ...useC(),
     [\`testA\${useH()}testB\`]: useI() === useJ(),
-    a: useK() ? 'a' : 'b'
+    a: useK() ? 'a' : 'b',
+    b: <div>{useL()}</div>,
+    c: <>{useM()}{useN()}</>
   };
 }"
 `;

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -1,5 +1,17 @@
 // Vitest Snapshot v1
 
+exports[`hooks > should correct transform any nested hooks call 1`] = `
+"import { useA, useB, useC, useD, useE, useF, useG, useH } from 'whatever';
+function Example(props) {
+  let a = null;
+  return useA(useB(), [useC(), 'array'], {
+    d: useD(),
+    [useE()]: useF(),
+    ...useG()
+  }, \`testA\${useH()}testB\`, useI() === useJ(), a = useK(), ...useJ());
+}"
+`;
+
 exports[`hooks > should correct transform nested hooks call (issue #14) 1`] = `
 "import { useDeferredValue } from 'react';
 import { useAtomValue } from 'jotai';

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -12,6 +12,27 @@ function Example(props) {
 }"
 `;
 
+exports[`hooks > should correct transform derived hooks call 1`] = `
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$equals as _$$equals } from \\"forgetti/runtime\\";
+import { useA, useB, useC } from 'whatever';
+function Example(props) {
+  let _c = _$$cache(_useMemo, 3),
+    a = null,
+    _eq = _$$equals(_c, 0, useA()),
+    _v = _eq ? _c[0] : _c[0] = useA(),
+    _eq2 = _$$equals(_c, 1, useC()),
+    _v2 = _eq2 ? _c[1] : _c[1] = useC(),
+    _eq3 = _eq && _eq2,
+    _v3 = _eq3 ? _c[2] : _c[2] = {
+      [_v]: useB(),
+      ..._v2
+    };
+  return _v3;
+}"
+`;
+
 exports[`hooks > should correct transform nested hooks call (issue #14) 1`] = `
 "import { useDeferredValue } from 'react';
 import { useAtomValue } from 'jotai';

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -13,23 +13,15 @@ function Example(props) {
 `;
 
 exports[`hooks > should correct transform derived hooks call 1`] = `
-"import { useMemo as _useMemo } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
-import { $$equals as _$$equals } from \\"forgetti/runtime\\";
-import { useA, useB, useC } from 'whatever';
+"import { useA, useB, useC } from 'whatever';
 function Example(props) {
-  let _c = _$$cache(_useMemo, 3),
-    a = null,
-    _eq = _$$equals(_c, 0, useA()),
-    _v = _eq ? _c[0] : _c[0] = useA(),
-    _eq2 = _$$equals(_c, 1, useC()),
-    _v2 = _eq2 ? _c[1] : _c[1] = useC(),
-    _eq3 = _eq && _eq2,
-    _v3 = _eq3 ? _c[2] : _c[2] = {
-      [_v]: useB(),
-      ..._v2
-    };
-  return _v3;
+  let a = null;
+  return {
+    [useA()]: useB(),
+    ...useC(),
+    [\`testA\${useH()}testB\`]: useI() === useJ(),
+    a: useK() ? 'a' : 'b'
+  };
 }"
 `;
 

--- a/packages/forgetti/test/hooks.test.ts
+++ b/packages/forgetti/test/hooks.test.ts
@@ -125,4 +125,23 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
+  it('should correct transform any nested hooks call', async () => {
+    const code = `
+import { useA, useB, useC, useD, useE, useF, useG, useH } from 'whatever'
+
+function Example(props) {
+  let a = null;
+  return useA(
+    useB(),
+    [useC(), 'array'],
+    { d: useD(), [useE()]: useF(), ...useG() },
+    \`testA\${useH()}testB\`,
+    useI() === useJ(),
+    (a = useK()),
+    ...useJ()
+  );
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
 });

--- a/packages/forgetti/test/hooks.test.ts
+++ b/packages/forgetti/test/hooks.test.ts
@@ -150,7 +150,12 @@ import { useA, useB, useC } from 'whatever'
 
 function Example(props) {
   let a = null;
-  return { [useA()]: useB(), ...useC(), [\`testA\${useH()}testB\`]: useI() === useJ() }
+  return {
+    [useA()]: useB(),
+    ...useC(),
+    [\`testA\${useH()}testB\`]: useI() === useJ(),
+    a: useK() ? 'a' : 'b'
+  }
 }
 `;
     expect(await compile(code)).toMatchSnapshot();

--- a/packages/forgetti/test/hooks.test.ts
+++ b/packages/forgetti/test/hooks.test.ts
@@ -154,7 +154,9 @@ function Example(props) {
     [useA()]: useB(),
     ...useC(),
     [\`testA\${useH()}testB\`]: useI() === useJ(),
-    a: useK() ? 'a' : 'b'
+    a: useK() ? 'a' : 'b',
+    b: <div>{useL()}</div>,
+    c: <>{useM()}{useN()}</>
   }
 }
 `;

--- a/packages/forgetti/test/hooks.test.ts
+++ b/packages/forgetti/test/hooks.test.ts
@@ -144,4 +144,15 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
+  it('should correct transform derived hooks call', async () => {
+    const code = `
+import { useA, useB, useC } from 'whatever'
+
+function Example(props) {
+  let a = null;
+  return { [useA()]: useB(), ...useC(), [\`testA\${useH()}testB\`]: useI() === useJ() }
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
The PR continues from #15.

The PR fixes these:

```jsx
import { useA, useB, useC, useD, useE, useF, useG, useH } from 'whatever'

function Example(props) {
  let a = null;
  return useA(
    useB(),
    [useC(), 'array'],
    { d: useD(), [useE()]: useF(), ...useG() },
    `testA${useH()}testB`,
    useI() === useJ(),
    (a = useK()),
    ...useJ()
  );
}
```
```jsx
import { useA, useB, useC } from 'whatever'

function Example(props) {
  let a = null;
  return { [useA()]: useB(), ...useC(), [`testA${useH()}testB`]: useI() === useJ(), assign: (a = useK()) }
}
```

The PR handles a lot more nested hook call cases. The unit test case is also added.