### PR TITLE
Test: run tests concurrently

### DIFF
--- a/packages/forgetti/test/expressions.test.ts
+++ b/packages/forgetti/test/expressions.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import * as babel from '@babel/core';
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import type { Options } from '../src';
 import plugin from '../src';
 
@@ -23,8 +23,8 @@ async function compile(code: string): Promise<string> {
   return result?.code ?? '';
 }
 
-describe('expressions', () => {
-  it('should optimize guaranteed literals', async () => {
+describe.concurrent('expressions', () => {
+  it('should optimize guaranteed literals', async ({ expect }) => {
     const code = `
 function Example(props) {
   return 1 + 2;
@@ -32,7 +32,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize identifiers', async () => {
+  it('should optimize identifiers', async ({ expect }) => {
     const code = `
 function Example(props) {
   return props;
@@ -40,7 +40,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize member expressions', async () => {
+  it('should optimize member expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return props.example;
@@ -48,7 +48,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize conditional expressions', async () => {
+  it('should optimize conditional expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return props.a ? props.b : props.c;
@@ -56,7 +56,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize binary expressions', async () => {
+  it('should optimize binary expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return props.a + props.b;
@@ -64,7 +64,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize logical expressions', async () => {
+  it('should optimize logical expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return props.a && props.b;
@@ -72,7 +72,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize unary expressions', async () => {
+  it('should optimize unary expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return !props.a;
@@ -80,7 +80,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize call expressions', async () => {
+  it('should optimize call expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return props.call();
@@ -88,7 +88,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize function expressions', async () => {
+  it('should optimize function expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   const callback = () => {
@@ -98,7 +98,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize assignment expressions', async () => {
+  it('should optimize assignment expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   let a, b, c;
@@ -108,7 +108,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize array expressions', async () => {
+  it('should optimize array expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return [props.a, props.b, ...props.c];
@@ -116,7 +116,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize object expressions', async () => {
+  it('should optimize object expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return { a: props.a, b: props.b, ...props.c };
@@ -124,7 +124,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize new expressions', async () => {
+  it('should optimize new expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return new X(props);
@@ -132,7 +132,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize sequence expressions', async () => {
+  it('should optimize sequence expressions', async ({ expect }) => {
     const code = `
 function Example(props) {
   return props.a(), props.b();
@@ -140,7 +140,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize template literals', async () => {
+  it('should optimize template literals', async ({ expect }) => {
     const code = `
 function Example(props) {
   return \`\${props.a()}, \${props.b()}\`;
@@ -148,7 +148,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize tagged templates', async () => {
+  it('should optimize tagged templates', async ({ expect }) => {
     const code = `
 function Example(props) {
   return props.tag\`\${props.a()}, \${props.b()}\`;
@@ -156,7 +156,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize JSX Element', async () => {
+  it('should optimize JSX Element', async ({ expect }) => {
     const code = `
 function Example(props) {
   return (
@@ -169,7 +169,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize JSX Fragment', async () => {
+  it('should optimize JSX Fragment', async ({ expect }) => {
     const code = `
 function Example(props) {
   return (

--- a/packages/forgetti/test/forgetti-skip.test.ts
+++ b/packages/forgetti/test/forgetti-skip.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import * as babel from '@babel/core';
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import type { Options } from '../src';
 import plugin from '../src';
 
@@ -23,8 +23,8 @@ async function compile(code: string): Promise<string> {
   return result?.code ?? '';
 }
 
-describe('forgetti skip', () => {
-  it('should optimize non-skipped function declaration', async () => {
+describe.concurrent('forgetti skip', () => {
+  it('should optimize non-skipped function declaration', async ({ expect }) => {
     const code = `
 function Example(props) {
   return <h1 className={props.className}>{props.children}</h1>;
@@ -33,7 +33,7 @@ function Example(props) {
     expect(await compile(code)).toMatchSnapshot();
   });
 
-  it('should skip skipped function declaration', async () => {
+  it('should skip skipped function declaration', async ({ expect }) => {
     const code = `
 /* @forgetti skip */
 function Example(props) {
@@ -43,7 +43,7 @@ function Example(props) {
     expect(await compile(code)).toMatchSnapshot();
   });
 
-  it('should optimize non-skipped function expression', async () => {
+  it('should optimize non-skipped function expression', async ({ expect }) => {
     const code = `
 const Example = function (props) {
   return <h1 className={props.className}>{props.children}</h1>;
@@ -52,7 +52,7 @@ const Example = function (props) {
     expect(await compile(code)).toMatchSnapshot();
   });
 
-  it('should skip skipped function expression', async () => {
+  it('should skip skipped function expression', async ({ expect }) => {
     const code = `
 const /* @forgetti skip */ ExampleA = function (props) {
   return <h1 className={props.className}>{props.children}</h1>;
@@ -64,7 +64,7 @@ const /* @forgetti skip */ ExampleA = function (props) {
     expect(await compile(code)).toMatchSnapshot();
   });
 
-  it('should optimize non-skipped variable declaration', async () => {
+  it('should optimize non-skipped variable declaration', async ({ expect }) => {
     const code = `
 const Example = props => {
   return <h1 className={props.className}>{props.children}</h1>;
@@ -73,7 +73,7 @@ const Example = props => {
     expect(await compile(code)).toMatchSnapshot();
   });
 
-  it('should skip skipped variable declaration', async () => {
+  it('should skip skipped variable declaration', async ({ expect }) => {
     const code = `
 const /* @forgetti skip */ ExampleA = props => {
   return <h1 className={props.className}>{props.children}</h1>;

--- a/packages/forgetti/test/hooks.test.ts
+++ b/packages/forgetti/test/hooks.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import * as babel from '@babel/core';
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import type { Options } from '../src';
 import plugin from '../src';
 
@@ -23,8 +23,8 @@ async function compile(code: string): Promise<string> {
   return result?.code ?? '';
 }
 
-describe('hooks', () => {
-  it('should optimize useRef', async () => {
+describe.concurrent('hooks', () => {
+  it('should optimize useRef', async ({ expect }) => {
     const code = `
 import { useRef } from 'react';
 function Example(props) {
@@ -33,7 +33,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useMemo', async () => {
+  it('should optimize useMemo', async ({ expect }) => {
     const code = `
 import { useMemo } from 'react';
 function Example(props) {
@@ -42,7 +42,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useMemo with 0 dependencies', async () => {
+  it('should optimize useMemo with 0 dependencies', async ({ expect }) => {
     const code = `
 import { useMemo } from 'react';
 function Example(props) {
@@ -51,7 +51,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useMemo with auto dependencies', async () => {
+  it('should optimize useMemo with auto dependencies', async ({ expect }) => {
     const code = `
 import { useMemo } from 'react';
 function Example(props) {
@@ -60,7 +60,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useCallback', async () => {
+  it('should optimize useCallback', async ({ expect }) => {
     const code = `
 import { useCallback } from 'react';
 function Example(props) {
@@ -69,7 +69,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useCallback with 0 dependencies', async () => {
+  it('should optimize useCallback with 0 dependencies', async ({ expect }) => {
     const code = `
 import { useCallback } from 'react';
 function Example(props) {
@@ -78,7 +78,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useCallback with auto dependencies', async () => {
+  it('should optimize useCallback with auto dependencies', async ({ expect }) => {
     const code = `
 import { useCallback } from 'react';
 function Example(props) {
@@ -87,7 +87,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useEffect', async () => {
+  it('should optimize useEffect', async ({ expect }) => {
     const code = `
 import { useEffect } from 'react';
 function Example(props) {
@@ -96,7 +96,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useEffect with 0 dependencies', async () => {
+  it('should optimize useEffect with 0 dependencies', async ({ expect }) => {
     const code = `
 import { useEffect } from 'react';
 function Example(props) {
@@ -105,7 +105,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize useEffect with auto dependencies', async () => {
+  it('should optimize useEffect with auto dependencies', async ({ expect }) => {
     const code = `
 import { useEffect } from 'react';
 function Example(props) {
@@ -114,7 +114,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should correct transform nested hooks call (issue #14)', async () => {
+  it('should correct transform nested hooks call (issue #14)', async ({ expect }) => {
     const code = `
 import { useDeferredValue } from 'react';
 import { useAtomValue } from 'jotai';
@@ -125,7 +125,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should correct transform any nested hooks call', async () => {
+  it('should correct transform any nested hooks call', async ({ expect }) => {
     const code = `
 import { useA, useB, useC, useD, useE, useF, useG, useH } from 'whatever'
 
@@ -144,7 +144,7 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should correct transform derived hooks call', async () => {
+  it('should correct transform derived hooks call', async ({ expect }) => {
     const code = `
 import { useA, useB, useC } from 'whatever'
 

--- a/packages/forgetti/test/index.test.ts
+++ b/packages/forgetti/test/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import * as babel from '@babel/core';
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import type { Options } from '../src';
 import plugin from '../src';
 
@@ -23,8 +23,8 @@ async function compile(code: string): Promise<string> {
   return result?.code ?? '';
 }
 
-describe('statements', () => {
-  it('should optimize for-of statements', async () => {
+describe.concurrent('statements', () => {
+  it('should optimize for-of statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     return props.a && props.b && props.c && props.d;

--- a/packages/forgetti/test/statements.test.ts
+++ b/packages/forgetti/test/statements.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import * as babel from '@babel/core';
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import type { Options } from '../src';
 import plugin from '../src';
 
@@ -23,8 +23,8 @@ async function compile(code: string): Promise<string> {
   return result?.code ?? '';
 }
 
-describe('statements', () => {
-  it('should optimize for-of statements', async () => {
+describe.concurrent('statements', () => {
+  it('should optimize for-of statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     for (const x of props.arr) {
@@ -34,7 +34,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize for-in statements', async () => {
+  it('should optimize for-in statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     for (const x in props.arr) {
@@ -44,7 +44,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize for statements', async () => {
+  it('should optimize for statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     for (let i = 0; i < 10; i += 1) {
@@ -54,7 +54,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize while statements', async () => {
+  it('should optimize while statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     let i = 0;
@@ -66,7 +66,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize do-while statements', async () => {
+  it('should optimize do-while statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     let i = 0;
@@ -78,7 +78,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize switch statements', async () => {
+  it('should optimize switch statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     switch (props.type) {
@@ -95,7 +95,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize if statements', async () => {
+  it('should optimize if statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     if (props.type === 'a') {
@@ -107,7 +107,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize try statements', async () => {
+  it('should optimize try statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     try {
@@ -121,7 +121,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize throw statements', async () => {
+  it('should optimize throw statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     throw createError(props.message);
@@ -129,7 +129,7 @@ describe('statements', () => {
   `;
     expect(await compile(code)).toMatchSnapshot();
   });
-  it('should optimize labeled statements', async () => {
+  it('should optimize labeled statements', async ({ expect }) => {
     const code = `
   function Example(props) {
     foo: {


### PR DESCRIPTION
Add `.concurrent` to `describe` to speed up tests.

The PR also removes `expect` from import, as the concurrent test with Snapshots and Assertions requires `expect` from the local test context.