### PR TITLE
Separate `$$ref` from `$$cache`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,14 @@ Here's an example preset:
       // Kind of import (named or default)
       kind: 'named',
     },
+    useMemo: {
+      // Name of the hook
+      name: 'useMemo',
+      // What module source does it come from
+      source: 'react',
+      // Kind of import (named or default)
+      kind: 'named',
+    },
     // Optional. Defining this means JSX optimization
     // is going to be enabled.
     memo: {

--- a/packages/forgetti/runtime/index.ts
+++ b/packages/forgetti/runtime/index.ts
@@ -12,12 +12,18 @@ export interface Ref<T> {
 }
 export type RefHook = <T>(callback: T) => Ref<T>;
 
-export function $$cache(hook: RefHook, size: number): unknown[] {
+export function $$ref(hook: RefHook, size: number): unknown[] {
   const ref = hook<unknown[] | undefined>(undefined);
   if (!ref.current) {
     ref.current = new Array(size);
   }
   return ref.current;
+}
+
+export type MemoHook = <T>(callback: () => T, dependencies: unknown[]) => T;
+
+export function $$cache(hook: MemoHook, size: number): unknown[] {
+  return hook(() => new Array<unknown>(size), []);
 }
 
 export function $$branch(parent: unknown[], index: number, size: number): unknown[] {

--- a/packages/forgetti/runtime/index.ts
+++ b/packages/forgetti/runtime/index.ts
@@ -22,8 +22,10 @@ export function $$ref(hook: RefHook, size: number): unknown[] {
 
 export type MemoHook = <T>(callback: () => T, dependencies: unknown[]) => T;
 
+const EMPTY_ARRAY: never[] = [];
+
 export function $$cache(hook: MemoHook, size: number): unknown[] {
-  return hook(() => new Array<unknown>(size), []);
+  return hook(() => new Array<unknown>(size), EMPTY_ARRAY);
 }
 
 export function $$branch(parent: unknown[], index: number, size: number): unknown[] {

--- a/packages/forgetti/src/core/imports.ts
+++ b/packages/forgetti/src/core/imports.ts
@@ -6,6 +6,12 @@ export const RUNTIME_EQUALS: ImportDefinition = {
   kind: 'named',
 };
 
+export const RUNTIME_REF: ImportDefinition = {
+  name: '$$ref',
+  source: 'forgetti/runtime',
+  kind: 'named',
+};
+
 export const RUNTIME_CACHE: ImportDefinition = {
   name: '$$cache',
   source: 'forgetti/runtime',

--- a/packages/forgetti/src/core/optimizer-scope.ts
+++ b/packages/forgetti/src/core/optimizer-scope.ts
@@ -2,7 +2,7 @@
 import * as t from '@babel/types';
 import type { OptimizedExpression, StateContext } from './types';
 import getImportIdentifier from './get-import-identifier';
-import { RUNTIME_BRANCH, RUNTIME_MEMO, RUNTIME_REF } from './imports';
+import { RUNTIME_BRANCH, RUNTIME_CACHE, RUNTIME_REF } from './imports';
 
 function mergeVariableDeclaration(statements: t.Statement[]): t.Statement[] {
   let stack: t.VariableDeclarator[] = [];
@@ -119,7 +119,7 @@ export default class OptimizerScope {
               getImportIdentifier(
                 this.ctx,
                 this.path,
-                RUNTIME_MEMO,
+                RUNTIME_CACHE,
               ),
               [
                 getImportIdentifier(

--- a/packages/forgetti/src/core/optimizer-scope.ts
+++ b/packages/forgetti/src/core/optimizer-scope.ts
@@ -2,7 +2,7 @@
 import * as t from '@babel/types';
 import type { OptimizedExpression, StateContext } from './types';
 import getImportIdentifier from './get-import-identifier';
-import { RUNTIME_BRANCH, RUNTIME_CACHE } from './imports';
+import { RUNTIME_BRANCH, RUNTIME_REF } from './imports';
 
 function mergeVariableDeclaration(statements: t.Statement[]): t.Statement[] {
   let stack: t.VariableDeclarator[] = [];
@@ -95,7 +95,7 @@ export default class OptimizerScope {
           getImportIdentifier(
             this.ctx,
             this.path,
-            RUNTIME_CACHE,
+            RUNTIME_REF,
           ),
           [
             getImportIdentifier(

--- a/packages/forgetti/src/core/optimizer-scope.ts
+++ b/packages/forgetti/src/core/optimizer-scope.ts
@@ -2,7 +2,7 @@
 import * as t from '@babel/types';
 import type { OptimizedExpression, StateContext } from './types';
 import getImportIdentifier from './get-import-identifier';
-import { RUNTIME_BRANCH, RUNTIME_MEMO } from './imports';
+import { RUNTIME_BRANCH, RUNTIME_MEMO, RUNTIME_REF } from './imports';
 
 function mergeVariableDeclaration(statements: t.Statement[]): t.Statement[] {
   let stack: t.VariableDeclarator[] = [];
@@ -26,7 +26,11 @@ function mergeVariableDeclaration(statements: t.Statement[]): t.Statement[] {
 export default class OptimizerScope {
   memo: t.Identifier | undefined;
 
-  indeces = 0;
+  ref: t.Identifier | undefined;
+
+  indecesMemo = 0;
+
+  indecesRef = 0;
 
   ctx: StateContext;
 
@@ -50,21 +54,33 @@ export default class OptimizerScope {
     this.isInLoop = isInLoop;
   }
 
-  createHeader(): t.Identifier {
+  createHeader(type: 'memo' | 'ref' = 'memo'): t.Identifier {
+    if (type === 'ref') {
+      if (!this.ref) {
+        this.ref = this.path.scope.generateUidIdentifier('ref');
+      }
+      return this.ref;
+    }
+
     if (!this.memo) {
       this.memo = this.path.scope.generateUidIdentifier('cache');
     }
     return this.memo;
   }
 
-  createIndex(): t.NumericLiteral {
-    const current = this.indeces;
-    this.indeces += 1;
+  createIndex(type: 'memo' | 'ref'): t.NumericLiteral {
+    const current = type === 'memo' ? this.indecesMemo : this.indecesRef;
+    if (type === 'memo') {
+      this.indecesMemo += 1;
+    } else {
+      this.indecesRef += 1;
+    }
+
     return t.numericLiteral(current);
   }
 
-  getMemoDeclaration(): t.VariableDeclaration | undefined {
-    if (!this.memo) {
+  getMemoDeclarations(): t.VariableDeclaration[] | undefined {
+    if (!this.memo && !this.ref) {
       return undefined;
     }
     // This is for generating branched caching.
@@ -72,42 +88,78 @@ export default class OptimizerScope {
     // from the parent (or root)
     if (this.parent) {
       const header = this.parent.createHeader();
-      const index = this.parent.createIndex();
+      const index = this.parent.createIndex('memo');
 
-      return t.variableDeclaration('let', [
-        t.variableDeclarator(
-          this.createHeader(),
-          t.callExpression(
-            getImportIdentifier(
-              this.ctx,
-              this.path,
-              RUNTIME_BRANCH,
+      return [
+        t.variableDeclaration('let', [
+          t.variableDeclarator(
+            this.createHeader(),
+            t.callExpression(
+              getImportIdentifier(
+                this.ctx,
+                this.path,
+                RUNTIME_BRANCH,
+              ),
+              [header, index, t.numericLiteral(this.indecesMemo)],
             ),
-            [header, index, t.numericLiteral(this.indeces)],
           ),
-        ),
-      ]);
+        ]),
+      ];
     }
-    return t.variableDeclaration('let', [
-      t.variableDeclarator(
-        this.memo,
-        t.callExpression(
-          getImportIdentifier(
-            this.ctx,
-            this.path,
-            RUNTIME_MEMO,
-          ),
-          [
-            getImportIdentifier(
-              this.ctx,
-              this.path,
-              this.ctx.preset.runtime.useMemo,
+
+    const outputDeclarations = [];
+
+    if (this.memo) {
+      outputDeclarations.push(
+
+        t.variableDeclaration('let', [
+          t.variableDeclarator(
+            this.memo,
+            t.callExpression(
+              getImportIdentifier(
+                this.ctx,
+                this.path,
+                RUNTIME_MEMO,
+              ),
+              [
+                getImportIdentifier(
+                  this.ctx,
+                  this.path,
+                  this.ctx.preset.runtime.useMemo,
+                ),
+                t.numericLiteral(this.indecesMemo),
+              ],
             ),
-            t.numericLiteral(this.indeces),
-          ],
-        ),
-      ),
-    ]);
+          ),
+        ]),
+      );
+    }
+    if (this.ref) {
+      outputDeclarations.push(
+        t.variableDeclaration('let', [
+          t.variableDeclarator(
+            this.ref,
+            t.callExpression(
+              getImportIdentifier(
+                this.ctx,
+                this.path,
+                RUNTIME_REF,
+              ),
+              [
+                getImportIdentifier(
+                  this.ctx,
+                  this.path,
+                  this.ctx.preset.runtime.useRef,
+                ),
+                t.numericLiteral(this.indecesRef),
+              ],
+            ),
+          ),
+        ]),
+      );
+    }
+
+    return outputDeclarations;
   }
 
   loop: t.Identifier | undefined;
@@ -133,7 +185,7 @@ export default class OptimizerScope {
       return undefined;
     }
     const header = this.parent.createHeader();
-    const index = this.parent.createIndex();
+    const index = this.parent.createIndex('memo');
     const id = this.createLoopIndex();
 
     return t.variableDeclaration('let', [
@@ -168,7 +220,7 @@ export default class OptimizerScope {
             this.path,
             RUNTIME_BRANCH,
           ),
-          [header, localIndex, t.numericLiteral(this.indeces)],
+          [header, localIndex, t.numericLiteral(this.indecesMemo)],
         ),
       ),
     ]);
@@ -177,11 +229,11 @@ export default class OptimizerScope {
   getStatements(): t.Statement[] {
     const result = [...this.statements];
     const header = this.isInLoop
-      ? this.getLoopDeclaration()
-      : this.getMemoDeclaration();
+      ? [this.getLoopDeclaration()]
+      : this.getMemoDeclarations();
     if (header) {
       return mergeVariableDeclaration([
-        header,
+        ...header,
         ...result,
       ]);
     }

--- a/packages/forgetti/src/core/optimizer-scope.ts
+++ b/packages/forgetti/src/core/optimizer-scope.ts
@@ -2,7 +2,7 @@
 import * as t from '@babel/types';
 import type { OptimizedExpression, StateContext } from './types';
 import getImportIdentifier from './get-import-identifier';
-import { RUNTIME_BRANCH, RUNTIME_REF } from './imports';
+import { RUNTIME_BRANCH, RUNTIME_MEMO } from './imports';
 
 function mergeVariableDeclaration(statements: t.Statement[]): t.Statement[] {
   let stack: t.VariableDeclarator[] = [];
@@ -95,13 +95,13 @@ export default class OptimizerScope {
           getImportIdentifier(
             this.ctx,
             this.path,
-            RUNTIME_REF,
+            RUNTIME_MEMO,
           ),
           [
             getImportIdentifier(
               this.ctx,
               this.path,
-              this.ctx.preset.runtime.useRef,
+              this.ctx.preset.runtime.useMemo,
             ),
             t.numericLiteral(this.indeces),
           ],

--- a/packages/forgetti/src/core/optimizer.ts
+++ b/packages/forgetti/src/core/optimizer.ts
@@ -73,6 +73,7 @@ export default class Optimizer {
   createMemo(
     current: t.Expression,
     dependencies?: t.Expression | (t.Expression | undefined)[] | boolean,
+    isUseRef = false,
   ): OptimizedExpression {
     // Check if the identifier is an already optimized
     // identifier so that we can skip it.
@@ -86,10 +87,10 @@ export default class Optimizer {
     const header = (
       this.scope.isInLoop
         ? this.scope.createLoopHeader()
-        : this.scope.createHeader()
+        : this.scope.createHeader(isUseRef ? 'ref' : 'memo')
     );
     // Get the memo index
-    const index = this.scope.createIndex();
+    const index = this.scope.createIndex(isUseRef ? 'ref' : 'memo');
     // Generate the access expression
     const pos = t.memberExpression(header, index, true);
     // Generate the `v` identifier
@@ -484,7 +485,7 @@ export default class Optimizer {
         init || t.identifier('undefined'),
       ),
     ]);
-    return this.createMemo(expr, true);
+    return this.createMemo(expr, true, true);
   }
 
   optimizeCallExpression(

--- a/packages/forgetti/src/core/optimizer.ts
+++ b/packages/forgetti/src/core/optimizer.ts
@@ -73,7 +73,7 @@ export default class Optimizer {
   createMemo(
     current: t.Expression,
     dependencies?: t.Expression | (t.Expression | undefined)[] | boolean,
-    isUseRef = false,
+    type: 'memo' | 'ref' = 'memo',
   ): OptimizedExpression {
     // Check if the identifier is an already optimized
     // identifier so that we can skip it.
@@ -87,10 +87,10 @@ export default class Optimizer {
     const header = (
       this.scope.isInLoop
         ? this.scope.createLoopHeader()
-        : this.scope.createHeader(isUseRef ? 'ref' : 'memo')
+        : this.scope.createHeader(type)
     );
     // Get the memo index
-    const index = this.scope.createIndex(isUseRef ? 'ref' : 'memo');
+    const index = this.scope.createIndex(type);
     // Generate the access expression
     const pos = t.memberExpression(header, index, true);
     // Generate the `v` identifier
@@ -485,7 +485,7 @@ export default class Optimizer {
         init || t.identifier('undefined'),
       ),
     ]);
-    return this.createMemo(expr, true, true);
+    return this.createMemo(expr, true, 'ref');
   }
 
   optimizeCallExpression(

--- a/packages/forgetti/src/core/presets.ts
+++ b/packages/forgetti/src/core/presets.ts
@@ -33,6 +33,7 @@ export interface Preset {
   };
   runtime: {
     useRef: ImportDefinition;
+    useMemo: ImportDefinition;
     memo?: ImportDefinition;
   };
   imports: {
@@ -64,6 +65,11 @@ export const PRESETS = {
     runtime: {
       useRef: {
         name: 'useRef',
+        source: 'react',
+        kind: 'named',
+      },
+      useMemo: {
+        name: 'useMemo',
         source: 'react',
         kind: 'named',
       },
@@ -140,6 +146,11 @@ export const PRESETS = {
     runtime: {
       useRef: {
         name: 'useRef',
+        source: 'preact/hooks',
+        kind: 'named',
+      },
+      useMemo: {
+        name: 'useMemo',
         source: 'preact/hooks',
         kind: 'named',
       },

--- a/packages/forgetti/test/__snapshots__/expressions.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/expressions.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`expressions > should optimize JSX Element 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -10,7 +11,7 @@ const _Memo = _$$memo(_memo, _values => <div>
       {_values[2]}
     </div>);
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 10),
+  let _cache = _$$cache(_useMemo, 10),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.title,
@@ -31,6 +32,7 @@ function Example(props) {
 
 exports[`expressions > should optimize JSX Fragment 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -39,7 +41,7 @@ const _Memo = _$$memo(_memo, _values => <>
       {_values[2]}
     </>);
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 10),
+  let _cache = _$$cache(_useMemo, 10),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.title,
@@ -60,10 +62,10 @@ function Example(props) {
 
 exports[`expressions > should optimize array expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 8),
+  let _cache = _$$cache(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -81,10 +83,10 @@ function Example(props) {
 
 exports[`expressions > should optimize assignment expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 5),
+  let _cache = _$$cache(_useMemo, 5),
     a,
     b,
     c,
@@ -99,10 +101,10 @@ function Example(props) {
 
 exports[`expressions > should optimize binary expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 6),
+  let _cache = _$$cache(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -117,10 +119,10 @@ function Example(props) {
 
 exports[`expressions > should optimize call expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 2),
+  let _cache = _$$cache(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.call();
@@ -129,11 +131,11 @@ function Example(props) {
 
 exports[`expressions > should optimize conditional expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 4),
+  let _cache = _$$cache(_useMemo, 4),
     _equals = _$$equals(_cache, 0, props),
     _value2 = _equals ? _cache[0] : _cache[0] = props,
     _value;
@@ -154,10 +156,10 @@ function Example(props) {
 
 exports[`expressions > should optimize function expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 2),
+  let _cache = _$$cache(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   const callback = _equals ? _cache[1] : _cache[1] = () => {
@@ -168,30 +170,30 @@ function Example(props) {
 
 exports[`expressions > should optimize guaranteed literals 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 1);
+  let _cache = _$$cache(_useMemo, 1);
   return 0 in _cache ? _cache[0] : _cache[0] = 1 + 2;
 }"
 `;
 
 exports[`expressions > should optimize identifiers 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 1);
+  let _cache = _$$cache(_useMemo, 1);
   return _$$equals(_cache, 0, props) ? _cache[0] : _cache[0] = props;
 }"
 `;
 
 exports[`expressions > should optimize logical expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 3),
+  let _cache = _$$cache(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _condition = _equals ? _cache[1] : _cache[1] = _value.a;
@@ -207,10 +209,10 @@ function Example(props) {
 
 exports[`expressions > should optimize member expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 2),
+  let _cache = _$$cache(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.example;
@@ -219,10 +221,10 @@ function Example(props) {
 
 exports[`expressions > should optimize new expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 3),
+  let _cache = _$$cache(_useMemo, 3),
     _value = 0 in _cache ? _cache[0] : _cache[0] = X,
     _equals = _$$equals(_cache, 1, props),
     _value2 = _equals ? _cache[1] : _cache[1] = props;
@@ -232,10 +234,10 @@ function Example(props) {
 
 exports[`expressions > should optimize object expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 6),
+  let _cache = _$$cache(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -253,11 +255,11 @@ function Example(props) {
 
 exports[`expressions > should optimize optional call expression 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 7),
+  let _cache = _$$cache(_useMemo, 7),
     _nullish,
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
@@ -289,11 +291,11 @@ function Example(props) {
 
 exports[`expressions > should optimize optional member expression 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 14),
+  let _cache = _$$cache(_useMemo, 14),
     _nullish,
     _nullish2,
     _equals = _$$equals(_cache, 0, props),
@@ -339,10 +341,10 @@ function Example(props) {
 
 exports[`expressions > should optimize sequence expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 3),
+  let _cache = _$$cache(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.a(), _equals ? _cache[2] : _cache[2] = _value.b();
@@ -351,10 +353,10 @@ function Example(props) {
 
 exports[`expressions > should optimize tagged templates 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 8),
+  let _cache = _$$cache(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.tag,
@@ -372,10 +374,10 @@ function Example(props) {
 
 exports[`expressions > should optimize template literals 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 6),
+  let _cache = _$$cache(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a(),
@@ -390,10 +392,10 @@ function Example(props) {
 
 exports[`expressions > should optimize unary expressions 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 4),
+  let _cache = _$$cache(_useMemo, 4),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,

--- a/packages/forgetti/test/__snapshots__/expressions.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/expressions.test.ts.snap
@@ -1,8 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`expressions > should optimize JSX Element 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -11,7 +10,7 @@ const _Memo = _$$memo(_memo, _values => <div>
       {_values[2]}
     </div>);
 function Example(props) {
-  let _cache = _$$ref(_useRef, 10),
+  let _cache = _$$memo(_useMemo, 10),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.title,
@@ -31,8 +30,7 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize JSX Fragment 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -41,7 +39,7 @@ const _Memo = _$$memo(_memo, _values => <>
       {_values[2]}
     </>);
 function Example(props) {
-  let _cache = _$$ref(_useRef, 10),
+  let _cache = _$$memo(_useMemo, 10),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.title,
@@ -61,11 +59,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize array expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 8),
+  let _cache = _$$memo(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -82,11 +80,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize assignment expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 5),
+  let _cache = _$$memo(_useMemo, 5),
     a,
     b,
     c,
@@ -100,11 +98,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize binary expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 6),
+  let _cache = _$$memo(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -118,11 +116,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize call expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 2),
+  let _cache = _$$memo(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.call();
@@ -130,12 +128,12 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize conditional expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 4),
+  let _cache = _$$memo(_useMemo, 4),
     _equals = _$$equals(_cache, 0, props),
     _value2 = _equals ? _cache[0] : _cache[0] = props,
     _value;
@@ -155,11 +153,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize function expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 2),
+  let _cache = _$$memo(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   const callback = _equals ? _cache[1] : _cache[1] = () => {
@@ -169,31 +167,31 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize guaranteed literals 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 1);
+  let _cache = _$$memo(_useMemo, 1);
   return 0 in _cache ? _cache[0] : _cache[0] = 1 + 2;
 }"
 `;
 
 exports[`expressions > should optimize identifiers 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 1);
+  let _cache = _$$memo(_useMemo, 1);
   return _$$equals(_cache, 0, props) ? _cache[0] : _cache[0] = props;
 }"
 `;
 
 exports[`expressions > should optimize logical expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 3),
+  let _cache = _$$memo(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _condition = _equals ? _cache[1] : _cache[1] = _value.a;
@@ -208,11 +206,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize member expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 2),
+  let _cache = _$$memo(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.example;
@@ -220,11 +218,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize new expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 3),
+  let _cache = _$$memo(_useMemo, 3),
     _value = 0 in _cache ? _cache[0] : _cache[0] = X,
     _equals = _$$equals(_cache, 1, props),
     _value2 = _equals ? _cache[1] : _cache[1] = props;
@@ -233,11 +231,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize object expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 6),
+  let _cache = _$$memo(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -254,12 +252,12 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize optional call expression 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 7),
+  let _cache = _$$memo(_useMemo, 7),
     _nullish,
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
@@ -290,12 +288,12 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize optional member expression 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 14),
+  let _cache = _$$memo(_useMemo, 14),
     _nullish,
     _nullish2,
     _equals = _$$equals(_cache, 0, props),
@@ -340,11 +338,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize sequence expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 3),
+  let _cache = _$$memo(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.a(), _equals ? _cache[2] : _cache[2] = _value.b();
@@ -352,11 +350,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize tagged templates 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 8),
+  let _cache = _$$memo(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.tag,
@@ -373,11 +371,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize template literals 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 6),
+  let _cache = _$$memo(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a(),
@@ -391,11 +389,11 @@ function Example(props) {
 `;
 
 exports[`expressions > should optimize unary expressions 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 4),
+  let _cache = _$$memo(_useMemo, 4),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,

--- a/packages/forgetti/test/__snapshots__/expressions.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/expressions.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`expressions > should optimize JSX Element 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -11,7 +11,7 @@ const _Memo = _$$memo(_memo, _values => <div>
       {_values[2]}
     </div>);
 function Example(props) {
-  let _cache = _$$cache(_useRef, 10),
+  let _cache = _$$ref(_useRef, 10),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.title,
@@ -32,7 +32,7 @@ function Example(props) {
 
 exports[`expressions > should optimize JSX Fragment 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -41,7 +41,7 @@ const _Memo = _$$memo(_memo, _values => <>
       {_values[2]}
     </>);
 function Example(props) {
-  let _cache = _$$cache(_useRef, 10),
+  let _cache = _$$ref(_useRef, 10),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.title,
@@ -62,10 +62,10 @@ function Example(props) {
 
 exports[`expressions > should optimize array expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 8),
+  let _cache = _$$ref(_useRef, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -83,10 +83,10 @@ function Example(props) {
 
 exports[`expressions > should optimize assignment expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 5),
+  let _cache = _$$ref(_useRef, 5),
     a,
     b,
     c,
@@ -101,10 +101,10 @@ function Example(props) {
 
 exports[`expressions > should optimize binary expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 6),
+  let _cache = _$$ref(_useRef, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -119,10 +119,10 @@ function Example(props) {
 
 exports[`expressions > should optimize call expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 2),
+  let _cache = _$$ref(_useRef, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.call();
@@ -131,11 +131,11 @@ function Example(props) {
 
 exports[`expressions > should optimize conditional expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 4),
+  let _cache = _$$ref(_useRef, 4),
     _equals = _$$equals(_cache, 0, props),
     _value2 = _equals ? _cache[0] : _cache[0] = props,
     _value;
@@ -156,10 +156,10 @@ function Example(props) {
 
 exports[`expressions > should optimize function expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 2),
+  let _cache = _$$ref(_useRef, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   const callback = _equals ? _cache[1] : _cache[1] = () => {
@@ -170,30 +170,30 @@ function Example(props) {
 
 exports[`expressions > should optimize guaranteed literals 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 1);
+  let _cache = _$$ref(_useRef, 1);
   return 0 in _cache ? _cache[0] : _cache[0] = 1 + 2;
 }"
 `;
 
 exports[`expressions > should optimize identifiers 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 1);
+  let _cache = _$$ref(_useRef, 1);
   return _$$equals(_cache, 0, props) ? _cache[0] : _cache[0] = props;
 }"
 `;
 
 exports[`expressions > should optimize logical expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 3),
+  let _cache = _$$ref(_useRef, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _condition = _equals ? _cache[1] : _cache[1] = _value.a;
@@ -209,10 +209,10 @@ function Example(props) {
 
 exports[`expressions > should optimize member expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 2),
+  let _cache = _$$ref(_useRef, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.example;
@@ -221,10 +221,10 @@ function Example(props) {
 
 exports[`expressions > should optimize new expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 3),
+  let _cache = _$$ref(_useRef, 3),
     _value = 0 in _cache ? _cache[0] : _cache[0] = X,
     _equals = _$$equals(_cache, 1, props),
     _value2 = _equals ? _cache[1] : _cache[1] = props;
@@ -234,10 +234,10 @@ function Example(props) {
 
 exports[`expressions > should optimize object expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 6),
+  let _cache = _$$ref(_useRef, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
@@ -255,11 +255,11 @@ function Example(props) {
 
 exports[`expressions > should optimize optional call expression 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 7),
+  let _cache = _$$ref(_useRef, 7),
     _nullish,
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
@@ -291,11 +291,11 @@ function Example(props) {
 
 exports[`expressions > should optimize optional member expression 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 14),
+  let _cache = _$$ref(_useRef, 14),
     _nullish,
     _nullish2,
     _equals = _$$equals(_cache, 0, props),
@@ -341,10 +341,10 @@ function Example(props) {
 
 exports[`expressions > should optimize sequence expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 3),
+  let _cache = _$$ref(_useRef, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = _value.a(), _equals ? _cache[2] : _cache[2] = _value.b();
@@ -353,10 +353,10 @@ function Example(props) {
 
 exports[`expressions > should optimize tagged templates 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 8),
+  let _cache = _$$ref(_useRef, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.tag,
@@ -374,10 +374,10 @@ function Example(props) {
 
 exports[`expressions > should optimize template literals 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 6),
+  let _cache = _$$ref(_useRef, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a(),
@@ -392,10 +392,10 @@ function Example(props) {
 
 exports[`expressions > should optimize unary expressions 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 4),
+  let _cache = _$$ref(_useRef, 4),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,

--- a/packages/forgetti/test/__snapshots__/forgetti-skip.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/forgetti-skip.test.ts.snap
@@ -2,13 +2,13 @@
 
 exports[`forgetti skip > should optimize non-skipped function declaration 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 function Example(props) {
-  let _cache = _$$cache(_useRef, 8),
+  let _cache = _$$ref(_useRef, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,
@@ -26,13 +26,13 @@ function Example(props) {
 
 exports[`forgetti skip > should optimize non-skipped function expression 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 const Example = function (props) {
-  let _cache = _$$cache(_useRef, 8),
+  let _cache = _$$ref(_useRef, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,
@@ -50,13 +50,13 @@ const Example = function (props) {
 
 exports[`forgetti skip > should optimize non-skipped variable declaration 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 const Example = props => {
-  let _cache = _$$cache(_useRef, 8),
+  let _cache = _$$ref(_useRef, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,

--- a/packages/forgetti/test/__snapshots__/forgetti-skip.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/forgetti-skip.test.ts.snap
@@ -1,14 +1,13 @@
 // Vitest Snapshot v1
 
 exports[`forgetti skip > should optimize non-skipped function declaration 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 function Example(props) {
-  let _cache = _$$ref(_useRef, 8),
+  let _cache = _$$memo(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,
@@ -25,14 +24,13 @@ function Example(props) {
 `;
 
 exports[`forgetti skip > should optimize non-skipped function expression 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 const Example = function (props) {
-  let _cache = _$$ref(_useRef, 8),
+  let _cache = _$$memo(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,
@@ -49,14 +47,13 @@ const Example = function (props) {
 `;
 
 exports[`forgetti skip > should optimize non-skipped variable declaration 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 const Example = props => {
-  let _cache = _$$ref(_useRef, 8),
+  let _cache = _$$memo(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,

--- a/packages/forgetti/test/__snapshots__/forgetti-skip.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/forgetti-skip.test.ts.snap
@@ -2,12 +2,13 @@
 
 exports[`forgetti skip > should optimize non-skipped function declaration 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 8),
+  let _cache = _$$cache(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,
@@ -25,12 +26,13 @@ function Example(props) {
 
 exports[`forgetti skip > should optimize non-skipped function expression 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 const Example = function (props) {
-  let _cache = _$$memo(_useMemo, 8),
+  let _cache = _$$cache(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,
@@ -48,12 +50,13 @@ const Example = function (props) {
 
 exports[`forgetti skip > should optimize non-skipped variable declaration 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 const _Memo = _$$memo(_memo, _values => <h1 className={_values[0]}>{_values[1]}</h1>);
 const Example = props => {
-  let _cache = _$$memo(_useMemo, 8),
+  let _cache = _$$cache(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.className,

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`hooks > should correct transform any nested hooks call 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useA, useB, useC, useD, useE, useF, useG, useH } from 'whatever';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 20),
+  let _cache = _$$ref(_useRef, 20),
     a = null,
     _hoisted = useB(),
     _hoisted2 = useC(),
@@ -50,7 +50,7 @@ function Example(props) {
 
 exports[`hooks > should correct transform derived hooks call 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -58,7 +58,7 @@ const _Memo = _$$memo(_memo, _values => <div>{_values[0]}</div>),
   _Memo2 = _$$memo(_memo, _values2 => <>{_values2[0]}{_values2[1]}</>);
 import { useA, useB, useC } from 'whatever';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 20),
+  let _cache = _$$ref(_useRef, 20),
     a = null,
     _hoisted = useA(),
     _hoisted2 = useB(),
@@ -120,13 +120,13 @@ function Example(props) {
 
 exports[`hooks > should correct transform nested hooks call (issue #14) 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useDeferredValue } from 'react';
 import { useAtomValue } from 'jotai';
 import { stateAtom } from 'whatever';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 2),
+  let _cache = _$$ref(_useRef, 2),
     _hoisted = useAtomValue(0 in _cache ? _cache[0] : _cache[0] = stateAtom);
   return useDeferredValue(_$$equals(_cache, 1, _hoisted) ? _cache[1] : _cache[1] = _hoisted);
 }"
@@ -134,11 +134,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useCallback 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 5),
+  let _cache = _$$ref(_useRef, 5),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.value,
@@ -151,10 +151,10 @@ function Example(props) {
 
 exports[`hooks > should optimize useCallback with 0 dependencies 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 2),
+  let _cache = _$$ref(_useRef, 2),
     _value = 0 in _cache ? _cache[0] : _cache[0] = [];
   return 1 in _cache ? _cache[1] : _cache[1] = () => props.value();
 }"
@@ -162,11 +162,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useCallback with auto dependencies 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 2),
+  let _cache = _$$ref(_useRef, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = () => props.value();
@@ -175,11 +175,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useEffect 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 4),
+  let _cache = _$$ref(_useRef, 4),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.example,
@@ -191,21 +191,21 @@ function Example(props) {
 
 exports[`hooks > should optimize useEffect with 0 dependencies 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 1);
+  let _cache = _$$ref(_useRef, 1);
   useEffect(() => props.value(), [0 in _cache ? _cache[0] : _cache[0] = []]);
 }"
 `;
 
 exports[`hooks > should optimize useEffect with auto dependencies 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 2),
+  let _cache = _$$ref(_useRef, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = () => props.value();
@@ -215,11 +215,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useMemo 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 5),
+  let _cache = _$$ref(_useRef, 5),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.value,
@@ -232,10 +232,10 @@ function Example(props) {
 
 exports[`hooks > should optimize useMemo with 0 dependencies 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 2),
+  let _cache = _$$ref(_useRef, 2),
     _value = 0 in _cache ? _cache[0] : _cache[0] = [];
   return 1 in _cache ? _cache[1] : _cache[1] = (() => props.value())();
 }"
@@ -243,11 +243,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useMemo with auto dependencies 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 3),
+  let _cache = _$$ref(_useRef, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = () => props.value();
@@ -257,10 +257,10 @@ function Example(props) {
 
 exports[`hooks > should optimize useRef 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { useRef } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useRef, 1);
+  let _cache = _$$ref(_useRef, 1);
   return 0 in _cache ? _cache[0] : _cache[0] = {
     current: props.value
   };

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -266,3 +266,27 @@ function Example(props) {
   };
 }"
 `;
+
+exports[`hooks > should optimize useRef and useMemo 1`] = `
+"import { useRef as _useRef } from \\"react\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$equals as _$$equals } from \\"forgetti/runtime\\";
+import { useRef } from 'react';
+function Example(props) {
+  let _cache = _$$cache(_useMemo, 7),
+    _ref = _$$ref(_useRef, 1);
+  const aRef = 0 in _ref ? _ref[0] : _ref[0] = {
+    current: props.foo
+  };
+  let _equals = _$$equals(_cache, 0, props),
+    _value2 = _equals ? _cache[0] : _cache[0] = props,
+    _value3 = _equals ? _cache[1] : _cache[1] = () => props.bar(),
+    _value5 = _equals ? _cache[3] : _cache[3] = _value2.bar,
+    _equals3 = _$$equals(_cache, 4, _value5),
+    _value6 = _equals3 ? _cache[4] : _cache[4] = _value5,
+    _value7 = _equals3 ? _cache[5] : _cache[5] = [_value6];
+  return useMemo(_$$equals(_cache, 2, _value3) ? _cache[2] : _cache[2] = _value3, _$$equals(_cache, 6, _value7) ? _cache[6] : _cache[6] = _value7);
+}"
+`;

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -255,12 +255,12 @@ function Example(props) {
 `;
 
 exports[`hooks > should optimize useRef 1`] = `
-"import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+"import { useRef as _useRef } from \\"react\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { useRef } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 1);
-  return 0 in _cache ? _cache[0] : _cache[0] = {
+  let _ref = _$$ref(_useRef, 1);
+  return 0 in _ref ? _ref[0] : _ref[0] = {
     current: props.value
   };
 }"

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -273,20 +273,19 @@ import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { useMemo as _useMemo } from \\"react\\";
 import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$cache(_useMemo, 7),
+  let _cache = _$$cache(_useMemo, 5),
     _ref = _$$ref(_useRef, 1);
   const aRef = 0 in _ref ? _ref[0] : _ref[0] = {
     current: props.foo
   };
   let _equals = _$$equals(_cache, 0, props),
     _value2 = _equals ? _cache[0] : _cache[0] = props,
-    _value3 = _equals ? _cache[1] : _cache[1] = () => props.bar(),
-    _value5 = _equals ? _cache[3] : _cache[3] = _value2.bar,
-    _equals3 = _$$equals(_cache, 4, _value5),
-    _value6 = _equals3 ? _cache[4] : _cache[4] = _value5,
-    _value7 = _equals3 ? _cache[5] : _cache[5] = [_value6];
-  return useMemo(_$$equals(_cache, 2, _value3) ? _cache[2] : _cache[2] = _value3, _$$equals(_cache, 6, _value7) ? _cache[6] : _cache[6] = _value7);
+    _value3 = _equals ? _cache[1] : _cache[1] = _value2.bar,
+    _equals2 = _$$equals(_cache, 2, _value3),
+    _value4 = _equals2 ? _cache[2] : _cache[2] = _value3,
+    _value5 = _equals2 ? _cache[3] : _cache[3] = [_value4];
+  return _equals2 ? _cache[4] : _cache[4] = (() => props.bar())();
 }"
 `;

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1
 
 exports[`hooks > should correct transform any nested hooks call 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useA, useB, useC, useD, useE, useF, useG, useH } from 'whatever';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 20),
+  let _cache = _$$memo(_useMemo, 20),
     a = null,
     _hoisted = useB(),
     _hoisted2 = useC(),
@@ -49,8 +49,7 @@ function Example(props) {
 `;
 
 exports[`hooks > should correct transform derived hooks call 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -58,7 +57,7 @@ const _Memo = _$$memo(_memo, _values => <div>{_values[0]}</div>),
   _Memo2 = _$$memo(_memo, _values2 => <>{_values2[0]}{_values2[1]}</>);
 import { useA, useB, useC } from 'whatever';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 20),
+  let _cache = _$$memo(_useMemo, 20),
     a = null,
     _hoisted = useA(),
     _hoisted2 = useB(),
@@ -119,26 +118,26 @@ function Example(props) {
 `;
 
 exports[`hooks > should correct transform nested hooks call (issue #14) 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useDeferredValue } from 'react';
 import { useAtomValue } from 'jotai';
 import { stateAtom } from 'whatever';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 2),
+  let _cache = _$$memo(_useMemo, 2),
     _hoisted = useAtomValue(0 in _cache ? _cache[0] : _cache[0] = stateAtom);
   return useDeferredValue(_$$equals(_cache, 1, _hoisted) ? _cache[1] : _cache[1] = _hoisted);
 }"
 `;
 
 exports[`hooks > should optimize useCallback 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 5),
+  let _cache = _$$memo(_useMemo, 5),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.value,
@@ -150,23 +149,23 @@ function Example(props) {
 `;
 
 exports[`hooks > should optimize useCallback with 0 dependencies 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 2),
+  let _cache = _$$memo(_useMemo, 2),
     _value = 0 in _cache ? _cache[0] : _cache[0] = [];
   return 1 in _cache ? _cache[1] : _cache[1] = () => props.value();
 }"
 `;
 
 exports[`hooks > should optimize useCallback with auto dependencies 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 2),
+  let _cache = _$$memo(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = () => props.value();
@@ -174,12 +173,12 @@ function Example(props) {
 `;
 
 exports[`hooks > should optimize useEffect 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 4),
+  let _cache = _$$memo(_useMemo, 4),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.example,
@@ -190,22 +189,22 @@ function Example(props) {
 `;
 
 exports[`hooks > should optimize useEffect with 0 dependencies 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 1);
+  let _cache = _$$memo(_useMemo, 1);
   useEffect(() => props.value(), [0 in _cache ? _cache[0] : _cache[0] = []]);
 }"
 `;
 
 exports[`hooks > should optimize useEffect with auto dependencies 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 2),
+  let _cache = _$$memo(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = () => props.value();
@@ -214,12 +213,12 @@ function Example(props) {
 `;
 
 exports[`hooks > should optimize useMemo 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 5),
+  let _cache = _$$memo(_useMemo, 5),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.value,
@@ -231,23 +230,23 @@ function Example(props) {
 `;
 
 exports[`hooks > should optimize useMemo with 0 dependencies 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 2),
+  let _cache = _$$memo(_useMemo, 2),
     _value = 0 in _cache ? _cache[0] : _cache[0] = [];
   return 1 in _cache ? _cache[1] : _cache[1] = (() => props.value())();
 }"
 `;
 
 exports[`hooks > should optimize useMemo with auto dependencies 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 3),
+  let _cache = _$$memo(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = () => props.value();
@@ -256,11 +255,11 @@ function Example(props) {
 `;
 
 exports[`hooks > should optimize useRef 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { useRef } from 'react';
 function Example(props) {
-  let _cache = _$$ref(_useRef, 1);
+  let _cache = _$$memo(_useMemo, 1);
   return 0 in _cache ? _cache[0] : _cache[0] = {
     current: props.value
   };

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`hooks > should correct transform any nested hooks call 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useA, useB, useC, useD, useE, useF, useG, useH } from 'whatever';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 20),
+  let _cache = _$$cache(_useMemo, 20),
     a = null,
     _hoisted = useB(),
     _hoisted2 = useC(),
@@ -50,6 +50,7 @@ function Example(props) {
 
 exports[`hooks > should correct transform derived hooks call 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { memo as _memo } from \\"react\\";
 import { $$memo as _$$memo } from \\"forgetti/runtime\\";
@@ -57,7 +58,7 @@ const _Memo = _$$memo(_memo, _values => <div>{_values[0]}</div>),
   _Memo2 = _$$memo(_memo, _values2 => <>{_values2[0]}{_values2[1]}</>);
 import { useA, useB, useC } from 'whatever';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 20),
+  let _cache = _$$cache(_useMemo, 20),
     a = null,
     _hoisted = useA(),
     _hoisted2 = useB(),
@@ -119,13 +120,13 @@ function Example(props) {
 
 exports[`hooks > should correct transform nested hooks call (issue #14) 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useDeferredValue } from 'react';
 import { useAtomValue } from 'jotai';
 import { stateAtom } from 'whatever';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 2),
+  let _cache = _$$cache(_useMemo, 2),
     _hoisted = useAtomValue(0 in _cache ? _cache[0] : _cache[0] = stateAtom);
   return useDeferredValue(_$$equals(_cache, 1, _hoisted) ? _cache[1] : _cache[1] = _hoisted);
 }"
@@ -133,11 +134,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useCallback 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 5),
+  let _cache = _$$cache(_useMemo, 5),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.value,
@@ -150,10 +151,10 @@ function Example(props) {
 
 exports[`hooks > should optimize useCallback with 0 dependencies 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 2),
+  let _cache = _$$cache(_useMemo, 2),
     _value = 0 in _cache ? _cache[0] : _cache[0] = [];
   return 1 in _cache ? _cache[1] : _cache[1] = () => props.value();
 }"
@@ -161,11 +162,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useCallback with auto dependencies 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useCallback } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 2),
+  let _cache = _$$cache(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   return _equals ? _cache[1] : _cache[1] = () => props.value();
@@ -174,11 +175,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useEffect 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 4),
+  let _cache = _$$cache(_useMemo, 4),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.example,
@@ -190,21 +191,21 @@ function Example(props) {
 
 exports[`hooks > should optimize useEffect with 0 dependencies 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 1);
+  let _cache = _$$cache(_useMemo, 1);
   useEffect(() => props.value(), [0 in _cache ? _cache[0] : _cache[0] = []]);
 }"
 `;
 
 exports[`hooks > should optimize useEffect with auto dependencies 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useEffect } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 2),
+  let _cache = _$$cache(_useMemo, 2),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = () => props.value();
@@ -214,11 +215,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useMemo 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 5),
+  let _cache = _$$cache(_useMemo, 5),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.value,
@@ -231,10 +232,10 @@ function Example(props) {
 
 exports[`hooks > should optimize useMemo with 0 dependencies 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 2),
+  let _cache = _$$cache(_useMemo, 2),
     _value = 0 in _cache ? _cache[0] : _cache[0] = [];
   return 1 in _cache ? _cache[1] : _cache[1] = (() => props.value())();
 }"
@@ -242,11 +243,11 @@ function Example(props) {
 
 exports[`hooks > should optimize useMemo with auto dependencies 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 import { useMemo } from 'react';
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 3),
+  let _cache = _$$cache(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = () => props.value();

--- a/packages/forgetti/test/__snapshots__/statements.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/statements.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`statements > should optimize do-while statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
   let i = 0,
-    _cache = _$$branch(_$$cache(_useRef, 1), 0, 0),
+    _cache = _$$branch(_$$ref(_useRef, 1), 0, 0),
     _id = 0;
   do {
     let _loop = _$$branch(_cache, _id++, 2),
@@ -21,11 +21,11 @@ function Example(props) {
 
 exports[`statements > should optimize for statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$branch(_$$cache(_useRef, 1), 0, 0),
+  let _cache = _$$branch(_$$ref(_useRef, 1), 0, 0),
     _id = 0;
   for (let i = 0; i < 10; i += 1) {
     let _loop = _$$branch(_cache, _id++, 2),
@@ -38,11 +38,11 @@ function Example(props) {
 
 exports[`statements > should optimize for-in statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 3),
+  let _cache = _$$ref(_useRef, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.arr,
@@ -59,11 +59,11 @@ function Example(props) {
 
 exports[`statements > should optimize for-of statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 3),
+  let _cache = _$$ref(_useRef, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.arr,
@@ -80,11 +80,11 @@ function Example(props) {
 
 exports[`statements > should optimize if statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 6),
+  let _cache = _$$ref(_useRef, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.type,
@@ -112,10 +112,10 @@ function Example(props) {
 
 exports[`statements > should optimize labeled statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache3 = _$$cache(_useRef, 2);
+  let _cache3 = _$$ref(_useRef, 2);
   foo: {
     let _cache2 = _$$branch(_cache3, 0, 1);
     {
@@ -131,11 +131,11 @@ function Example(props) {
 
 exports[`statements > should optimize switch statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 6),
+  let _cache = _$$ref(_useRef, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   switch (_equals ? _cache[1] : _cache[1] = _value.type) {
@@ -177,10 +177,10 @@ function Example(props) {
 
 exports[`statements > should optimize throw statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useRef, 5),
+  let _cache = _$$ref(_useRef, 5),
     _value = 0 in _cache ? _cache[0] : _cache[0] = createError,
     _equals = _$$equals(_cache, 1, props),
     _value2 = _equals ? _cache[1] : _cache[1] = props,
@@ -193,11 +193,11 @@ function Example(props) {
 
 exports[`statements > should optimize try statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache2 = _$$cache(_useRef, 3);
+  let _cache2 = _$$ref(_useRef, 3);
   try {
     let _cache = _$$branch(_cache2, 0, 2),
       _equals = _$$equals(_cache, 0, props),
@@ -221,12 +221,12 @@ function Example(props) {
 
 exports[`statements > should optimize while statements 1`] = `
 "import { useRef as _useRef } from \\"react\\";
-import { $$cache as _$$cache } from \\"forgetti/runtime\\";
+import { $$ref as _$$ref } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
   let i = 0,
-    _cache = _$$branch(_$$cache(_useRef, 1), 0, 0),
+    _cache = _$$branch(_$$ref(_useRef, 1), 0, 0),
     _id = 0;
   while (i < props.x) {
     let _loop = _$$branch(_cache, _id++, 2),

--- a/packages/forgetti/test/__snapshots__/statements.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/statements.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`statements > should optimize do-while statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
   let i = 0,
-    _cache = _$$branch(_$$memo(_useMemo, 1), 0, 0),
+    _cache = _$$branch(_$$cache(_useMemo, 1), 0, 0),
     _id = 0;
   do {
     let _loop = _$$branch(_cache, _id++, 2),
@@ -21,11 +21,11 @@ function Example(props) {
 
 exports[`statements > should optimize for statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$branch(_$$memo(_useMemo, 1), 0, 0),
+  let _cache = _$$branch(_$$cache(_useMemo, 1), 0, 0),
     _id = 0;
   for (let i = 0; i < 10; i += 1) {
     let _loop = _$$branch(_cache, _id++, 2),
@@ -38,11 +38,11 @@ function Example(props) {
 
 exports[`statements > should optimize for-in statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 3),
+  let _cache = _$$cache(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.arr,
@@ -59,11 +59,11 @@ function Example(props) {
 
 exports[`statements > should optimize for-of statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 3),
+  let _cache = _$$cache(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.arr,
@@ -80,11 +80,11 @@ function Example(props) {
 
 exports[`statements > should optimize if statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 6),
+  let _cache = _$$cache(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.type,
@@ -112,10 +112,10 @@ function Example(props) {
 
 exports[`statements > should optimize labeled statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache3 = _$$memo(_useMemo, 2);
+  let _cache3 = _$$cache(_useMemo, 2);
   foo: {
     let _cache2 = _$$branch(_cache3, 0, 1);
     {
@@ -131,11 +131,11 @@ function Example(props) {
 
 exports[`statements > should optimize switch statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 6),
+  let _cache = _$$cache(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   switch (_equals ? _cache[1] : _cache[1] = _value.type) {
@@ -177,10 +177,10 @@ function Example(props) {
 
 exports[`statements > should optimize throw statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$memo(_useMemo, 5),
+  let _cache = _$$cache(_useMemo, 5),
     _value = 0 in _cache ? _cache[0] : _cache[0] = createError,
     _equals = _$$equals(_cache, 1, props),
     _value2 = _equals ? _cache[1] : _cache[1] = props,
@@ -193,11 +193,11 @@ function Example(props) {
 
 exports[`statements > should optimize try statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache2 = _$$memo(_useMemo, 3);
+  let _cache2 = _$$cache(_useMemo, 3);
   try {
     let _cache = _$$branch(_cache2, 0, 2),
       _equals = _$$equals(_cache, 0, props),
@@ -221,12 +221,12 @@ function Example(props) {
 
 exports[`statements > should optimize while statements 1`] = `
 "import { useMemo as _useMemo } from \\"react\\";
-import { $$memo as _$$memo } from \\"forgetti/runtime\\";
+import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
   let i = 0,
-    _cache = _$$branch(_$$memo(_useMemo, 1), 0, 0),
+    _cache = _$$branch(_$$cache(_useMemo, 1), 0, 0),
     _id = 0;
   while (i < props.x) {
     let _loop = _$$branch(_cache, _id++, 2),

--- a/packages/forgetti/test/__snapshots__/statements.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/statements.test.ts.snap
@@ -1,13 +1,13 @@
 // Vitest Snapshot v1
 
 exports[`statements > should optimize do-while statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
   let i = 0,
-    _cache = _$$branch(_$$ref(_useRef, 1), 0, 0),
+    _cache = _$$branch(_$$memo(_useMemo, 1), 0, 0),
     _id = 0;
   do {
     let _loop = _$$branch(_cache, _id++, 2),
@@ -20,12 +20,12 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize for statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$branch(_$$ref(_useRef, 1), 0, 0),
+  let _cache = _$$branch(_$$memo(_useMemo, 1), 0, 0),
     _id = 0;
   for (let i = 0; i < 10; i += 1) {
     let _loop = _$$branch(_cache, _id++, 2),
@@ -37,12 +37,12 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize for-in statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 3),
+  let _cache = _$$memo(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.arr,
@@ -58,12 +58,12 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize for-of statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 3),
+  let _cache = _$$memo(_useMemo, 3),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.arr,
@@ -79,12 +79,12 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize if statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 6),
+  let _cache = _$$memo(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.type,
@@ -111,11 +111,11 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize labeled statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache3 = _$$ref(_useRef, 2);
+  let _cache3 = _$$memo(_useMemo, 2);
   foo: {
     let _cache2 = _$$branch(_cache3, 0, 1);
     {
@@ -130,12 +130,12 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize switch statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 6),
+  let _cache = _$$memo(_useMemo, 6),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props;
   switch (_equals ? _cache[1] : _cache[1] = _value.type) {
@@ -176,11 +176,11 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize throw statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$ref(_useRef, 5),
+  let _cache = _$$memo(_useMemo, 5),
     _value = 0 in _cache ? _cache[0] : _cache[0] = createError,
     _equals = _$$equals(_cache, 1, props),
     _value2 = _equals ? _cache[1] : _cache[1] = props,
@@ -192,12 +192,12 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize try statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache2 = _$$ref(_useRef, 3);
+  let _cache2 = _$$memo(_useMemo, 3);
   try {
     let _cache = _$$branch(_cache2, 0, 2),
       _equals = _$$equals(_cache, 0, props),
@@ -220,13 +220,13 @@ function Example(props) {
 `;
 
 exports[`statements > should optimize while statements 1`] = `
-"import { useRef as _useRef } from \\"react\\";
-import { $$ref as _$$ref } from \\"forgetti/runtime\\";
+"import { useMemo as _useMemo } from \\"react\\";
+import { $$memo as _$$memo } from \\"forgetti/runtime\\";
 import { $$branch as _$$branch } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
   let i = 0,
-    _cache = _$$branch(_$$ref(_useRef, 1), 0, 0),
+    _cache = _$$branch(_$$memo(_useMemo, 1), 0, 0),
     _id = 0;
   while (i < props.x) {
     let _loop = _$$branch(_cache, _id++, 2),

--- a/packages/forgetti/test/hooks.test.ts
+++ b/packages/forgetti/test/hooks.test.ts
@@ -44,7 +44,7 @@ function Example(props) {
   });
   it('should optimize useRef and useMemo', async ({ expect }) => {
     const code = `
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 function Example(props) {
   const aRef = useRef(props.foo);
   return useMemo(() => props.bar(), [props.bar]);

--- a/packages/forgetti/test/hooks.test.ts
+++ b/packages/forgetti/test/hooks.test.ts
@@ -42,6 +42,16 @@ function Example(props) {
 `;
     expect(await compile(code)).toMatchSnapshot();
   });
+  it('should optimize useRef and useMemo', async ({ expect }) => {
+    const code = `
+import { useRef } from 'react';
+function Example(props) {
+  const aRef = useRef(props.foo);
+  return useMemo(() => props.bar(), [props.bar]);
+}
+`;
+    expect(await compile(code)).toMatchSnapshot();
+  });
   it('should optimize useMemo with 0 dependencies', async ({ expect }) => {
     const code = `
 import { useMemo } from 'react';


### PR DESCRIPTION
The PR does 2 things:

- Revert back from `useRef` to `useMemo` for cache
- Add a separate runtime `$$ref` to merging refs

This re-enables RSC support after 0.6.0.