### PR TITLE
fix: optimizeConditionalExpression lost dependencies #33

### DIFF
--- a/packages/forgetti/src/core/optimizer.ts
+++ b/packages/forgetti/src/core/optimizer.ts
@@ -653,7 +653,7 @@ export default class Optimizer {
         const valuePath = element.get('value');
 
         if (isPathValid(valuePath, t.isExpression)) {
-          const optimized = this.optimizeExpression(valuePath);
+          const optimized = this.createDependency(valuePath);
           if (optimized) {
             mergeDependencies(condition, optimized.deps);
             element.node.value = optimized.expr;

--- a/packages/forgetti/test/__snapshots__/expressions.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/expressions.test.ts.snap
@@ -237,18 +237,22 @@ exports[`expressions > should optimize object expressions 1`] = `
 import { $$cache as _$$cache } from \\"forgetti/runtime\\";
 import { $$equals as _$$equals } from \\"forgetti/runtime\\";
 function Example(props) {
-  let _cache = _$$cache(_useMemo, 6),
+  let _cache = _$$cache(_useMemo, 8),
     _equals = _$$equals(_cache, 0, props),
     _value = _equals ? _cache[0] : _cache[0] = props,
     _value2 = _equals ? _cache[1] : _cache[1] = _value.a,
-    _value3 = _equals ? _cache[2] : _cache[2] = _value.b,
-    _value4 = _equals ? _cache[3] : _cache[3] = _value.c,
-    _equals2 = _$$equals(_cache, 4, _value4),
-    _value5 = _equals2 ? _cache[4] : _cache[4] = _value4;
-  return _equals && _equals2 ? _cache[5] : _cache[5] = {
-    a: _value2,
-    b: _value3,
-    ..._value5
+    _equals2 = _$$equals(_cache, 2, _value2),
+    _value3 = _equals2 ? _cache[2] : _cache[2] = _value2,
+    _value4 = _equals ? _cache[3] : _cache[3] = _value.b,
+    _equals3 = _$$equals(_cache, 4, _value4),
+    _value5 = _equals3 ? _cache[4] : _cache[4] = _value4,
+    _value6 = _equals ? _cache[5] : _cache[5] = _value.c,
+    _equals4 = _$$equals(_cache, 6, _value6),
+    _value7 = _equals4 ? _cache[6] : _cache[6] = _value6;
+  return _equals2 && _equals3 && _equals4 ? _cache[7] : _cache[7] = {
+    a: _value3,
+    b: _value5,
+    ..._value7
   };
 }"
 `;

--- a/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
+++ b/packages/forgetti/test/__snapshots__/hooks.test.ts.snap
@@ -58,7 +58,7 @@ const _Memo = _$$memo(_memo, _values => <div>{_values[0]}</div>),
   _Memo2 = _$$memo(_memo, _values2 => <>{_values2[0]}{_values2[1]}</>);
 import { useA, useB, useC } from 'whatever';
 function Example(props) {
-  let _cache = _$$cache(_useMemo, 20),
+  let _cache = _$$cache(_useMemo, 24),
     a = null,
     _hoisted = useA(),
     _hoisted2 = useB(),
@@ -85,35 +85,42 @@ function Example(props) {
     _value7 = _equals6 ? _cache[6] : _cache[6] = _hoisted5,
     _equals7 = _$$equals(_cache, 7, _hoisted6),
     _value8 = _equals7 ? _cache[7] : _cache[7] = _hoisted6,
-    _equals8 = _equals6 && _equals7,
-    _value9 = _equals8 ? _cache[8] : _cache[8] = _value7 === _value8,
-    _value10;
-  if (_$$equals(_cache, 9, _hoisted7) ? _cache[9] : _cache[9] = _hoisted7) {
-    _value10 = 'a';
+    _value9 = _equals6 && _equals7 ? _cache[8] : _cache[8] = _value7 === _value8,
+    _equals9 = _$$equals(_cache, 9, _value9),
+    _value10 = _equals9 ? _cache[9] : _cache[9] = _value9,
+    _value11;
+  if (_$$equals(_cache, 10, _hoisted7) ? _cache[10] : _cache[10] = _hoisted7) {
+    _value11 = 'a';
   } else {
-    _value10 = 'b';
+    _value11 = 'b';
   }
-  let _equals10 = _$$equals(_cache, 10, _hoisted8),
-    _value12 = _equals10 ? _cache[10] : _cache[10] = _hoisted8,
-    _value13 = _equals10 ? _cache[11] : _cache[11] = [_value12],
-    _equals11 = _$$equals(_cache, 12, _value13),
-    _value14 = _equals11 ? _cache[12] : _cache[12] = _value13,
-    _value15 = _equals11 ? _cache[13] : _cache[13] = /*@forgetti jsx*/<_Memo v={_value14} />,
-    _equals12 = _$$equals(_cache, 14, _hoisted9),
-    _value16 = _equals12 ? _cache[14] : _cache[14] = _hoisted9,
-    _equals13 = _$$equals(_cache, 15, _hoisted10),
-    _value17 = _equals13 ? _cache[15] : _cache[15] = _hoisted10,
-    _value18 = _equals12 && _equals13 ? _cache[16] : _cache[16] = [_value16, _value17],
-    _equals15 = _$$equals(_cache, 17, _value18),
-    _value19 = _equals15 ? _cache[17] : _cache[17] = _value18,
-    _value20 = _equals15 ? _cache[18] : _cache[18] = /*@forgetti jsx*/<_Memo2 v={_value19} />;
-  return _equals && _equals2 && _equals3 && _equals5 && _equals8 && _equals11 && _equals15 ? _cache[19] : _cache[19] = {
+  let _equals11 = _$$equals(_cache, 11, _value11),
+    _value13 = _equals11 ? _cache[11] : _cache[11] = _value11,
+    _equals12 = _$$equals(_cache, 12, _hoisted8),
+    _value14 = _equals12 ? _cache[12] : _cache[12] = _hoisted8,
+    _value15 = _equals12 ? _cache[13] : _cache[13] = [_value14],
+    _equals13 = _$$equals(_cache, 14, _value15),
+    _value16 = _equals13 ? _cache[14] : _cache[14] = _value15,
+    _value17 = _equals13 ? _cache[15] : _cache[15] = /*@forgetti jsx*/<_Memo v={_value16} />,
+    _equals14 = _$$equals(_cache, 16, _value17),
+    _value18 = _equals14 ? _cache[16] : _cache[16] = _value17,
+    _equals15 = _$$equals(_cache, 17, _hoisted9),
+    _value19 = _equals15 ? _cache[17] : _cache[17] = _hoisted9,
+    _equals16 = _$$equals(_cache, 18, _hoisted10),
+    _value20 = _equals16 ? _cache[18] : _cache[18] = _hoisted10,
+    _value21 = _equals15 && _equals16 ? _cache[19] : _cache[19] = [_value19, _value20],
+    _equals18 = _$$equals(_cache, 20, _value21),
+    _value22 = _equals18 ? _cache[20] : _cache[20] = _value21,
+    _value23 = _equals18 ? _cache[21] : _cache[21] = /*@forgetti jsx*/<_Memo2 v={_value22} />,
+    _equals19 = _$$equals(_cache, 22, _value23),
+    _value24 = _equals19 ? _cache[22] : _cache[22] = _value23;
+  return _equals && _equals2 && _equals3 && _equals5 && _equals9 && _equals11 && _equals14 && _equals19 ? _cache[23] : _cache[23] = {
     [_value]: _value2,
     ..._value3,
-    [_value6]: _value9,
-    a: _value10,
-    b: _value15,
-    c: _value20
+    [_value6]: _value10,
+    a: _value13,
+    b: _value18,
+    c: _value24
   };
 }"
 `;


### PR DESCRIPTION
input:
```js
import React, { useEffect, useState, memo } from 'react';

export default memo(function Test(props) {
  const b = {
    a: props.a ? 2 : 1,
  }
  return <div>{b.a}</div>
});

```
output: 
```js
import { useMemo as _useMemo } from "react";
import { $$cache as _$$cache } from "forgetti/runtime";
import { $$equals as _$$equals } from "forgetti/runtime";
import { memo as _memo } from "react";
import { $$memo as _$$memo } from "forgetti/runtime";
const _Memo = _$$memo(_memo, _values => <div>{_values[0]}</div>);
import React, { useEffect, useState, memo } from 'react';
export default memo(function (props) {
  let _cache = _$$cache(_useMemo, 11),
    _equals = _$$equals(_cache, 0, props),
    _value2 = _equals ? _cache[0] : _cache[0] = props,
    _value4 = _equals ? _cache[2] : _cache[2] = _value2.a,
    _equals2 = _$$equals(_cache, 3, _value4),
    _value5 = _equals2 ? _cache[3] : _cache[3] = _value4,
    _value;
  if (_equals ? _cache[1] : _cache[1] = _value2.a) {
    _value = 2;
  } else {
    _value = 1;
  }
  let _value6 = _equals2 ? _cache[4] : _cache[4] = {
      a: _value
    },
    _equals3 = _$$equals(_cache, 5, _value6),
    _value7 = _equals3 ? _cache[5] : _cache[5] = _value6,
    _value8 = _equals3 ? _cache[6] : _cache[6] = _value7.a,
    _equals4 = _$$equals(_cache, 7, _value8),
    _value9 = _equals4 ? _cache[7] : _cache[7] = _value8,
    _value10 = _equals4 ? _cache[8] : _cache[8] = [_value9],
    _equals5 = _$$equals(_cache, 9, _value10),
    _value11 = _equals5 ? _cache[9] : _cache[9] = _value10;
  return _equals5 ? _cache[10] : _cache[10] = /*@forgetti jsx*/<_Memo v={_value11} />;
});

```